### PR TITLE
Wrap eval-when-compile for suppressing byte-compile warning

### DIFF
--- a/ac-html-csswatcher.el
+++ b/ac-html-csswatcher.el
@@ -71,7 +71,8 @@
 ;;
 ;;; Code:
 
-(require 'cl)
+(eval-when-compile
+  (require 'cl))
 (require 'web-completion-data)
 
 (defvar ac-html-csswatcher-source-dir nil


### PR DESCRIPTION
Because this package uses only cl.el macros.

Loading cl.el at runtime causes byte-compile warning as below.

```
ac-html-csswatcher.el:74:1:Warning: cl package required at runtime
```
